### PR TITLE
Fix Auto-sharding Bug for Residual blocks.

### DIFF
--- a/parallax/sharding/auto_shard.py
+++ b/parallax/sharding/auto_shard.py
@@ -86,14 +86,18 @@ def get_shardings(
   params_assignments = []
   for var in jaxpr.jaxpr.invars[: len(params_flat)]:
     params_assignments.append([])
-    for i in range(var.aval.ndim):  # pytype: disable=attribute-error
+    dim_sharded= False
+    for i in range(var.aval.ndim - 1, -1, -1):  # pytype: disable=attribute-error
       root = graph.get_root((var, i))
-      if (model_axis is not None and (root, model_axis) in edges) or var.aval.shape[i] < min_shard_size:  # pytype: disable=attribute-error
+      if ((model_axis is None) or 
+         ((root, model_axis) in edges) or 
+         (var.aval.shape[i] < min_shard_size) or 
+         dim_sharded):
         params_assignments[-1].append(None)  # conflict with model axis
-      else:
-        params_assignments[-1].append(
-            model_axis_name if model_axis is not None else None
-        )
+      else:  # Assign model axis if not already sharded
+        params_assignments[-1].append(model_axis_name)
+        dim_sharded = True
+    params_assignments[-1].reverse() 
   params_assignments = params_treedef.unflatten(params_assignments)
 
   inputs_assignments = []

--- a/parallax/sharding/auto_shard_test.py
+++ b/parallax/sharding/auto_shard_test.py
@@ -26,6 +26,21 @@ NamedSharding = jax.sharding.NamedSharding
 P = jax.sharding.PartitionSpec
 
 
+class ResidualBlockModel(nnx.Module):
+
+  def __init__(self, rngs: nnx.Rngs):
+    self.linear1 = nnx.Linear(128, 64, rngs=rngs)
+    self.linear2 = nnx.Linear(64, 32, rngs=rngs)
+    self.linear3 = nnx.Linear(96, 8, rngs=rngs)
+
+  def __call__(self, x):
+    z1 = self.linear1(x)
+    z2 = self.linear2(z1)
+    z1_z2 = jnp.concatenate([z2, z1], axis=-1)
+    z3 = self.linear3(z1_z2)
+    return z3
+
+
 class AutoShardTest(parameterized.TestCase):
 
   def setUp(self):
@@ -277,6 +292,29 @@ class AutoShardTest(parameterized.TestCase):
     self.assertEqual(model_shd, expected_assignments[0])
     self.assertEqual(in_shd, expected_assignments[1])
     self.assertEqual(out_shd, expected_assignments[2])
+
+  def test_residual_block_w3_conflict(self):
+    model = ResidualBlockModel(rngs=nnx.Rngs(0))
+    inputs = (jnp.ones((32, 128)),)
+    graphdef, state = nnx.split(model)
+
+    def fn(state, *inputs):
+      model = nnx.merge(graphdef, state)
+      return model(*inputs)
+
+    (model_shd, *in_shd), out_shd = auto_shard.get_shardings(
+        fn, state, *inputs, min_shard_size=0
+    )
+    model_shd = nnx.to_pure_dict(model_shd)
+
+    expected_model_shd = {
+        'linear1': {'bias': P('model'), 'kernel': P(None, 'model')},
+        'linear2': {'bias': P(None), 'kernel': P('model', None)},
+        'linear3': {'bias': P('model'), 'kernel': P(None, 'model')},
+    }
+    self.assertEqual(model_shd, expected_model_shd)
+    self.assertEqual(in_shd, [P('data', None)])
+    self.assertEqual(out_shd, P('data', None))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix: Prevent sharding conflicts between non-primary axes in `auto_shard.py`

The current heuristic in `auto_shard.py` only checks for sharding conflicts against the single dominant `model_axis`. It does not account for conflicts that can arise between newly assigned non-primary axes.

**Problem:** When testing with a Residual Block, the existing code incorrectly caused the weight parameter of the `linear3` layer to be sharded on both dimensions using the `model_axis`.

**Solution:** To fix this bug, I have introduced a `dim_sharded` flag. This flag tracks whether a dimension has already been sharded while assigning the sharding axis to each parameter dimension, preventing erroneous double-sharding.

```
class ResidualBlockModel(nnx.Module):

  def __init__(self, rngs: nnx.Rngs):
    self.linear1 = nnx.Linear(128, 64, rngs=rngs)
    self.linear2 = nnx.Linear(64, 32, rngs=rngs)
    self.linear3 = nnx.Linear(96, 8, rngs=rngs)

  def __call__(self, x):
    z1 = self.linear1(x)
    z2 = self.linear2(z1)
    z1_z2 = jnp.concatenate([z2, z1], axis=-1)
    z3 = self.linear3(z1_z2)
    return z3
```

Reproduction script:
```
import os
os.environ['XLA_FLAGS'] = '--xla_force_host_platform_device_count=8'

import jax
import jax.numpy as jnp
from parallax.sharding import auto_shard
from flax import nnx

# Create a mesh for setup
mesh = jax.make_mesh(
    (4, 2),
    ('data', 'model'),
    axis_types=(jax.sharding.AxisType.Auto,) * 2,
)

with jax.set_mesh(mesh):
  def model_fn(params, x):
    w1, b1, w2, b2, w3, b3 = params
    z1 = jnp.dot(x, w1) + b1  # (32, 64)
    z2 = jnp.dot(z1, w2) + b2  # (32, 32)
    z1_z2 = jnp.concatenate([z2, z1], axis=-1)  # (32, 96)
    z3 = jnp.dot(z1_z2, w3) + b3  # (32, 8)
    return z3

  # Define shapes
  x = jnp.ones((32, 128))
  w1 = jnp.ones((128, 64))
  b1 = jnp.ones((64,))
  w2 = jnp.ones((64, 32))
  b2 = jnp.ones((32,))
  w3 = jnp.ones((96, 8))
  b3 = jnp.ones((8,))

  params = (w1, b1, w2, b2, w3, b3)
  params_name = ("W1", "b1", "W2", "b2", "W3", "b3")


  # Let's run get_shardings and see final assignments
  (params_shd, x_shd), out_shd = auto_shard.get_shardings(model_fn, params, x)
  print("\n--- SHARDING ASSIGNMENTS ---")
  print("Params Sharding Assignments:")
  for i, p_shd in enumerate(params_shd):
    print(f"  {params_name[i]}: {p_shd}")
  print(f"Input x Sharding Assignment: {x_shd}")
  print(f"Output z3 Sharding Assignment: {out_shd}")

```